### PR TITLE
Adapted CodeMirror5 style for mode addon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <link rel="stylesheet" href="https://unpkg.com/awsm.css@3.0.7/dist/awsm_theme_black.min.css">
-    <link rel="stylesheet" href="./codewars.css">
     <link rel="stylesheet" href="../../lib/codemirror.css">
+    <link rel="stylesheet" href="./codewars.css">
     <script src="../../lib/codemirror.js"></script>
     <script src="../../addon/mode/simple.js"></script>
     <script src="./riscv.js"></script>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <link rel="stylesheet" href="https://unpkg.com/awsm.css@3.0.7/dist/awsm_theme_black.min.css">
+    <link rel="stylesheet" href="./codewars.css">
+    <link rel="stylesheet" href="../../lib/codemirror.css">
+    <script src="../../lib/codemirror.js"></script>
+    <script src="../../addon/mode/simple.js"></script>
+    <script src="./riscv.js"></script>
     <style>
       .CodeMirror { margin: auto; }
       .text-center { text-align: center; }
@@ -34,14 +39,7 @@ multiply:
     </main>
 
     <script type="module">
-      import CodeMirror from "codemirror";
-      import "codemirror/addon/mode/simple.js";
-      import "codemirror/lib/codemirror.css";
-      import "./codewars.css";
-
-      import { defineMode } from "./riscv.js";
-      defineMode(CodeMirror);
-      const editor = CodeMirror.fromTextArea(document.getElementById("editor"), {
+      var editor = CodeMirror.fromTextArea(document.getElementById("editor"), {
         mode: "riscv",
         lineNumbers: true,
         theme: "codewars",

--- a/riscv.js
+++ b/riscv.js
@@ -1,3 +1,13 @@
+(function(mod) {
+  if (typeof exports == "object" && typeof module == "object") // CommonJS
+    mod(require("../../lib/codemirror"), require("../../addon/mode/simple"));
+  else if (typeof define == "function" && define.amd) // AMD
+    define(["../../lib/codemirror", "../../addon/mode/simple"], mod);
+  else // Plain browser env
+    mod(CodeMirror);
+})(function(CodeMirror) {
+"use strict";
+
 // prettier-ignore
 const directives = [
   // Architecture independent directives.
@@ -122,11 +132,9 @@ const extC = instructions([
   "c.slli", "c.srai", "c.srli", "c.sub", "c.subw", "c.sw", "c.swsp", "c.xor",
 ]);
 
-export const defineMode = (CodeMirror) => {
+
   CodeMirror.defineSimpleMode("riscv", {
-    meta: {
-      lineComment: "#",
-    },
+
     start: [
       { regex: /#.*/, token: "comment" },
 
@@ -157,7 +165,10 @@ export const defineMode = (CodeMirror) => {
       { regex: registers, token: "variable" },
       { regex: registerAbiNames, token: "variable-2" },
     ],
+    meta: {
+      lineComment: "#",
+    }
   });
 
   CodeMirror.defineMIME("text/x-riscv", "riscv");
-};
+});


### PR DESCRIPTION
Changes made in index.html and riscv.js to correspond with modes in CodeMirror5

To be placed in CodeMirror5 'mode' folder, now only small adjustments to 'meta.js' needed.